### PR TITLE
Add Windows and ARM builds

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,25 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vanilla-os/pico:main
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            ext: ""
+          - goos: linux
+            goarch: arm64
+            ext: ""
+          - goos: windows
+            goarch: amd64
+            ext: ".exe"
+          - goos: darwin
+            goarch: amd64
+            ext: ""
+          - goos: darwin
+            goarch: arm64
+            ext: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -17,16 +36,20 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Test
         run: go test -v ./...
 
       - name: Build
-        run: go build -o goup cmd/goup/main.go
+        env:
+          CGO_ENABLED: 0
+        run: |
+          mkdir -p dist
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o dist/goup-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} cmd/goup/main.go
 
       - uses: softprops/action-gh-release@v1
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
-            goup
+            dist/goup-*

--- a/internal/server/listen_optimized_default.go
+++ b/internal/server/listen_optimized_default.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package server
+
+import "net"
+
+func listenOptimized(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}

--- a/internal/server/listen_optimized_linux.go
+++ b/internal/server/listen_optimized_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// listenOptimized creates a TCP listener with SO_REUSEPORT and TCP_FASTOPEN optimizations.
+func listenOptimized(addr string) (net.Listener, error) {
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				unix.SetsockoptInt(int(fd), unix.SOL_TCP, unix.TCP_FASTOPEN, 256)
+			})
+		},
+	}
+	return lc.Listen(context.Background(), "tcp", addr)
+}

--- a/internal/server/server_utils.go
+++ b/internal/server/server_utils.go
@@ -1,19 +1,15 @@
 package server
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/mirkobrombin/goup/internal/config"
 	"github.com/mirkobrombin/goup/internal/logger"
 	"github.com/quic-go/quic-go/http3"
-	"golang.org/x/sys/unix"
 )
 
 // createHTTPServer creates an HTTP server with the given configuration and handler.
@@ -46,19 +42,6 @@ func createHTTPServer(conf config.SiteConfig, handler http.Handler) *http.Server
 	}
 
 	return s
-}
-
-// listenOptimized creates a TCP listener with SO_REUSEPORT and TCP_FASTOPEN optimizations.
-func listenOptimized(addr string) (net.Listener, error) {
-	lc := net.ListenConfig{
-		Control: func(network, address string, c syscall.RawConn) error {
-			return c.Control(func(fd uintptr) {
-				unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
-				unix.SetsockoptInt(int(fd), unix.SOL_TCP, unix.TCP_FASTOPEN, 256)
-			})
-		},
-	}
-	return lc.Listen(context.Background(), "tcp", addr)
 }
 
 // startServerInstance starts the HTTP server instance.

--- a/internal/server/static_handler.go
+++ b/internal/server/static_handler.go
@@ -7,6 +7,7 @@ import (
 	"mime"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,8 +17,17 @@ import (
 
 // ServeStatic serves static files with support for pre-compressed sidecar files (.br, .gz).
 func ServeStatic(w http.ResponseWriter, r *http.Request, root string) {
-	cleanPath := filepath.Clean(r.URL.Path)
-	fullPath := filepath.Join(root, cleanPath)
+	cleanPath, fullPath, err := staticLocalPath(root, r.URL.Path)
+	if err != nil {
+		if isBrowser(r) {
+			assets.RenderErrorPage(w, http.StatusNotFound, "Page Not Found", "The page you are looking for does not exist.")
+		} else {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintln(w, "404 Not Found")
+		}
+		return
+	}
 
 	info, err := os.Stat(fullPath)
 	if err != nil {
@@ -61,7 +71,7 @@ func ServeStatic(w http.ResponseWriter, r *http.Request, root string) {
 			info = indexInfo
 		} else {
 			// Directory listing or Welcome Page
-			if cleanPath == "/" || cleanPath == "." || cleanPath == "\\" {
+			if cleanPath == "/" {
 				// If index.html is missing at root, we can still show listing if it's not empty
 			}
 
@@ -89,7 +99,7 @@ func ServeStatic(w http.ResponseWriter, r *http.Request, root string) {
 					})
 				}
 
-				showBack := cleanPath != "/" && cleanPath != "." && cleanPath != "\\"
+				showBack := cleanPath != "/"
 				assets.RenderDirectoryListing(w, cleanPath, items, showBack)
 			} else {
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -190,4 +200,19 @@ func formatSizeBytes(b int64) string {
 func isBrowser(r *http.Request) bool {
 	accept := r.Header.Get("Accept")
 	return strings.Contains(accept, "text/html")
+}
+
+func staticLocalPath(root, urlPath string) (string, string, error) {
+	urlPath = strings.ReplaceAll(urlPath, "\\", "/")
+	cleanPath := path.Clean("/" + strings.TrimPrefix(urlPath, "/"))
+	relPath := strings.TrimPrefix(cleanPath, "/")
+	if relPath == "" {
+		return cleanPath, root, nil
+	}
+
+	localPath, err := filepath.Localize(relPath)
+	if err != nil {
+		return cleanPath, "", err
+	}
+	return cleanPath, filepath.Join(root, localPath), nil
 }

--- a/internal/server/static_handler_test.go
+++ b/internal/server/static_handler_test.go
@@ -146,3 +146,19 @@ func TestServeStatic_ContentNegotiation(t *testing.T) {
 		})
 	}
 }
+
+func TestStaticLocalPath_BackslashTraversal(t *testing.T) {
+	root := t.TempDir()
+
+	cleanPath, fullPath, err := staticLocalPath(root, `\..\secret.txt`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanPath != "/secret.txt" {
+		t.Fatalf("expected clean path /secret.txt, got %s", cleanPath)
+	}
+	expected := filepath.Join(root, "secret.txt")
+	if fullPath != expected {
+		t.Fatalf("expected local path %s, got %s", expected, fullPath)
+	}
+}

--- a/plugins/docker_base.go
+++ b/plugins/docker_base.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -92,7 +93,7 @@ func (d *DockerBasePlugin) OnInitForSite(conf config.SiteConfig, domainLogger *l
 	}
 
 	// Set default SocketPath.
-	if strings.ToLower(d.Config.CLICommand) == "podman" && d.Config.SocketPath == "" {
+	if runtime.GOOS != "windows" && strings.ToLower(d.Config.CLICommand) == "podman" && d.Config.SocketPath == "" {
 		userSocket := fmt.Sprintf("/run/user/%d/podman/podman.sock", os.Getuid())
 		if _, err := os.Stat(userSocket); err == nil {
 			d.Config.SocketPath = userSocket
@@ -100,7 +101,7 @@ func (d *DockerBasePlugin) OnInitForSite(conf config.SiteConfig, domainLogger *l
 			d.Config.SocketPath = "/run/podman/podman.sock"
 		}
 	}
-	if d.Config.SocketPath == "" {
+	if runtime.GOOS != "windows" && d.Config.SocketPath == "" {
 		d.Config.SocketPath = "/var/run/docker.sock"
 	}
 
@@ -146,6 +147,9 @@ func (d *DockerBasePlugin) ListContainers() (string, error) {
 
 func (d *DockerBasePlugin) callDockerAPI(method, path string, body []byte) (string, error) {
 	d.DomainLogger.Infof("[DockerBasePlugin] Calling Docker API: %s %s", method, path)
+	if runtime.GOOS == "windows" {
+		return "", fmt.Errorf("docker API over Unix socket is not supported on Windows")
+	}
 	socket := d.Config.SocketPath
 	if socket == "" {
 		socket = "/var/run/docker.sock"

--- a/plugins/php.go
+++ b/plugins/php.go
@@ -3,7 +3,9 @@ package plugins
 import (
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/mirkobrombin/goup/internal/config"
@@ -91,10 +93,15 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 		docRoot = "."
 	}
 
-	// Resolve the requested path under the document root. Anchoring the clean
-	// to "/" prevents path traversal from escaping the root.
-	cleanPath := filepath.Clean("/" + r.URL.Path)
-	fsPath := filepath.Join(docRoot, cleanPath)
+	// Resolve the requested path under the document root. Backslashes are
+	// normalized first so Windows-style separators cannot bypass the clean,
+	// and anchoring the clean to "/" prevents path traversal from escaping
+	// the root.
+	cleanPath := path.Clean("/" + strings.ReplaceAll(r.URL.Path, "\\", "/"))
+	fsPath, err := phpScriptPath(docRoot, cleanPath)
+	if err != nil {
+		return false
+	}
 
 	var scriptFilename, scriptName, pathInfo string
 
@@ -105,17 +112,17 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 		idxPath := filepath.Join(fsPath, "index.php")
 		if fi, err := os.Stat(idxPath); err == nil && !fi.IsDir() {
 			scriptFilename = idxPath
-			scriptName = strings.TrimSuffix(filepath.ToSlash(cleanPath), "/") + "/index.php"
+			scriptName = strings.TrimSuffix(cleanPath, "/") + "/index.php"
 		}
 
 	case statErr == nil:
 		// Existing file: execute it if it is PHP, otherwise let the static
 		// file server handle it (assets, css, js, images, ...).
-		if !strings.HasSuffix(fsPath, ".php") {
+		if !strings.HasSuffix(cleanPath, ".php") {
 			return false
 		}
 		scriptFilename = fsPath
-		scriptName = filepath.ToSlash(cleanPath)
+		scriptName = cleanPath
 	}
 
 	if scriptFilename == "" {
@@ -126,8 +133,11 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 		if front == "" {
 			front = "index.php"
 		}
-		frontClean := filepath.Clean("/" + front)
-		frontPath := filepath.Join(docRoot, frontClean)
+		frontClean := path.Clean("/" + strings.ReplaceAll(front, "\\", "/"))
+		frontPath, err := phpScriptPath(docRoot, frontClean)
+		if err != nil {
+			return false
+		}
 		fi, err := os.Stat(frontPath)
 		if err != nil || fi.IsDir() {
 			// No front controller available: fall through to the static
@@ -135,7 +145,7 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 			return false
 		}
 		scriptFilename = frontPath
-		scriptName = filepath.ToSlash(frontClean)
+		scriptName = frontClean
 		// Preserve the original URI as PATH_INFO so the app sees the route.
 		pathInfo = r.URL.Path
 	}
@@ -150,6 +160,10 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 
 	var connFactory gofast.ConnFactory
 	if strings.HasPrefix(phpFPMAddr, "/") {
+		if runtime.GOOS == "windows" {
+			http.Error(w, "Unix sockets are not supported on Windows", http.StatusInternalServerError)
+			return true
+		}
 		connFactory = gofast.SimpleConnFactory("unix", phpFPMAddr)
 	} else {
 		connFactory = gofast.SimpleConnFactory("tcp", phpFPMAddr)
@@ -164,7 +178,7 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 			req.Params["DOCUMENT_ROOT"] = docRoot
 			if pathInfo != "" {
 				req.Params["PATH_INFO"] = pathInfo
-				req.Params["PATH_TRANSLATED"] = filepath.Join(docRoot, filepath.Clean("/"+pathInfo))
+				req.Params["PATH_TRANSLATED"] = fsPath
 			}
 			req.Params["REQUEST_METHOD"] = r.Method
 			req.Params["SERVER_PROTOCOL"] = r.Proto
@@ -206,3 +220,16 @@ func (p *PHPPlugin) HandleRequest(w http.ResponseWriter, r *http.Request) bool {
 
 func (p *PHPPlugin) AfterRequest(w http.ResponseWriter, r *http.Request) {}
 func (p *PHPPlugin) OnExit() error                                       { return nil }
+
+func phpScriptPath(root, cleanPath string) (string, error) {
+	relPath := strings.TrimPrefix(cleanPath, "/")
+	if relPath == "" {
+		return root, nil
+	}
+
+	localPath, err := filepath.Localize(relPath)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, localPath), nil
+}


### PR DESCRIPTION
Closes #3.

- Release workflow now cross-compiles linux/amd64, linux/arm64, windows/amd64, darwin/amd64, darwin/arm64.
- CI aligned with the Go version required by go.mod.
- Portability fixes: path normalization and safe local path resolution in the static handler and PHP plugin (backslash handling, filepath.Localize), Linux-only socket optimizations moved behind build tags, unix sockets rejected on Windows with a clear error.

Verified: GOOS=windows/amd64, linux/arm64 and darwin/arm64 builds all compile; full test suite green.