### PR TITLE
Real-time dashboard via Datastar SSE

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -8,6 +8,8 @@ import (
 )
 
 func getConfigHandler(w http.ResponseWriter, r *http.Request) {
+	config.GlobalConfMu.RLock()
+	defer config.GlobalConfMu.RUnlock()
 	if config.GlobalConf == nil {
 		http.Error(w, "Global config not loaded", http.StatusInternalServerError)
 		return
@@ -16,19 +18,26 @@ func getConfigHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func updateConfigHandler(w http.ResponseWriter, r *http.Request) {
+	config.GlobalConfMu.RLock()
 	if config.GlobalConf == nil {
+		config.GlobalConfMu.RUnlock()
 		http.Error(w, "Global config not loaded", http.StatusInternalServerError)
 		return
 	}
+	config.GlobalConfMu.RUnlock()
 	var newConf config.GlobalConfig
 	if err := json.NewDecoder(r.Body).Decode(&newConf); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
+	config.GlobalConfMu.Lock()
 	config.GlobalConf = &newConf
+	config.GlobalConfMu.Unlock()
 	if err := config.SaveGlobalConfig(); err != nil {
 		http.Error(w, "Failed to save config", http.StatusInternalServerError)
 		return
 	}
+	config.GlobalConfMu.RLock()
+	defer config.GlobalConfMu.RUnlock()
 	jsonResponse(w, config.GlobalConf)
 }

--- a/internal/api/logs_metrics_status.go
+++ b/internal/api/logs_metrics_status.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mirkobrombin/goup/internal/config"
+	"github.com/mirkobrombin/goup/internal/monitor"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/mem"
 )
@@ -16,7 +17,7 @@ import (
 var startTime = time.Now()
 var requestsTotal uint64
 
-func getLogsHandler(w http.ResponseWriter, r *http.Request) {
+func LogsSnapshot() ([]byte, error) {
 	logDir := config.GetLogDir()
 	var logs []byte
 	err := filepath.Walk(logDir, func(path string, info fs.FileInfo, err error) error {
@@ -33,6 +34,11 @@ func getLogsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	})
+	return logs, err
+}
+
+func getLogsHandler(w http.ResponseWriter, r *http.Request) {
+	logs, err := LogsSnapshot()
 	if err != nil {
 		http.Error(w, "Unable to read log file", http.StatusInternalServerError)
 		return
@@ -41,32 +47,68 @@ func getLogsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(logs)
 }
 
-func getMetricsHandler(w http.ResponseWriter, r *http.Request) {
-	atomic.AddUint64(&requestsTotal, 1)
+func MetricsSnapshot() map[string]any {
 	cpuPercent, _ := cpu.Percent(0, false)
 	vm, _ := mem.VirtualMemory()
-	metrics := map[string]any{
-		"requests_total": atomic.LoadUint64(&requestsTotal),
+
+	activePlugins := 0
+	config.GlobalConfMu.RLock()
+	if config.GlobalConf != nil {
+		activePlugins = len(config.GlobalConf.EnabledPlugins)
+	}
+	config.GlobalConfMu.RUnlock()
+
+	config.SiteConfigsMu.RLock()
+	activeSites := len(config.SiteConfigs)
+	config.SiteConfigsMu.RUnlock()
+
+	requests := monitor.RequestCount()
+	if requests == 0 {
+		requests = atomic.LoadUint64(&requestsTotal)
+	}
+
+	return map[string]any{
+		"requests_total": requests,
 		"latency_avg_ms": 0,
 		"cpu_usage":      cpuPercent,
 		"ram_usage_mb":   vm.Used / 1024 / 1024,
-		"active_sites":   len(config.SiteConfigs),
-		"active_plugins": len(config.GlobalConf.EnabledPlugins),
+		"active_sites":   activeSites,
+		"active_plugins": activePlugins,
 	}
+}
+
+func getMetricsHandler(w http.ResponseWriter, r *http.Request) {
+	atomic.AddUint64(&requestsTotal, 1)
+	metrics := MetricsSnapshot()
 	jsonResponse(w, metrics)
 }
 
-func getStatusHandler(w http.ResponseWriter, r *http.Request) {
-	status := map[string]any{
+func StatusSnapshot() map[string]any {
+	plugins := []string{}
+	config.GlobalConfMu.RLock()
+	if config.GlobalConf != nil {
+		plugins = append(plugins, config.GlobalConf.EnabledPlugins...)
+	}
+	config.GlobalConfMu.RUnlock()
+
+	config.SiteConfigsMu.RLock()
+	sites := len(config.SiteConfigs)
+	config.SiteConfigsMu.RUnlock()
+
+	return map[string]any{
 		"uptime":   time.Since(startTime).String(),
-		"sites":    len(config.SiteConfigs),
-		"plugins":  config.GlobalConf.EnabledPlugins,
+		"sites":    sites,
+		"plugins":  plugins,
 		"apiAlive": true,
 	}
+}
+
+func getStatusHandler(w http.ResponseWriter, r *http.Request) {
+	status := StatusSnapshot()
 	jsonResponse(w, status)
 }
 
-func getLogWeightHandler(w http.ResponseWriter, r *http.Request) {
+func LogWeightSnapshot() (int64, error) {
 	logDir := config.GetLogDir()
 	var totalSize int64 = 0
 	err := filepath.Walk(logDir, func(_ string, info fs.FileInfo, err error) error {
@@ -78,6 +120,11 @@ func getLogWeightHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		return nil
 	})
+	return totalSize, err
+}
+
+func getLogWeightHandler(w http.ResponseWriter, r *http.Request) {
+	totalSize, err := LogWeightSnapshot()
 	if err != nil {
 		http.Error(w, "Error calculating log weight", http.StatusInternalServerError)
 		return
@@ -87,12 +134,19 @@ func getLogWeightHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func getPluginUsageHandler(w http.ResponseWriter, r *http.Request) {
+func PluginUsageSnapshot() map[string]int {
 	usage := make(map[string]int)
+	config.SiteConfigsMu.RLock()
+	defer config.SiteConfigsMu.RUnlock()
 	for _, site := range config.SiteConfigs {
 		for pluginName := range site.PluginConfigs {
 			usage[pluginName]++
 		}
 	}
+	return usage
+}
+
+func getPluginUsageHandler(w http.ResponseWriter, r *http.Request) {
+	usage := PluginUsageSnapshot()
 	jsonResponse(w, usage)
 }

--- a/internal/api/plugins.go
+++ b/internal/api/plugins.go
@@ -31,7 +31,9 @@ func togglePluginHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	pName := vars["pluginName"]
 
+	config.GlobalConfMu.Lock()
 	if config.GlobalConf == nil {
+		config.GlobalConfMu.Unlock()
 		http.Error(w, "Global config not loaded", http.StatusInternalServerError)
 		return
 	}
@@ -50,6 +52,8 @@ func togglePluginHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		config.GlobalConf.EnabledPlugins = append(config.GlobalConf.EnabledPlugins, pName)
 	}
+	config.GlobalConfMu.Unlock()
+
 	if err := config.SaveGlobalConfig(); err != nil {
 		http.Error(w, "Failed to save config", http.StatusInternalServerError)
 		return
@@ -64,6 +68,8 @@ func togglePluginHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func isPluginEnabled(name string) bool {
+	config.GlobalConfMu.RLock()
+	defer config.GlobalConfMu.RUnlock()
 	if config.GlobalConf == nil || len(config.GlobalConf.EnabledPlugins) == 0 {
 		return true
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,12 +10,16 @@ import (
 
 // StartAPIServer starts the GoUp API server.
 func StartAPIServer() *http.Server {
-	if config.GlobalConf == nil || !config.GlobalConf.EnableAPI {
+	config.GlobalConfMu.RLock()
+	conf := config.GlobalConf
+	config.GlobalConfMu.RUnlock()
+
+	if conf == nil || !conf.EnableAPI {
 		return nil
 	}
 
 	router := SetupRoutes()
-	port := config.GlobalConf.APIPort
+	port := conf.APIPort
 	var handler http.Handler = router
 	handler = middleware.TokenAuthMiddleware(handler)
 

--- a/internal/api/sites.go
+++ b/internal/api/sites.go
@@ -5,23 +5,36 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/gorilla/mux"
 	"github.com/mirkobrombin/goup/internal/config"
 )
 
-func listSitesHandler(w http.ResponseWriter, r *http.Request) {
+func SitesSnapshot() []config.SiteConfig {
 	var all []config.SiteConfig
+	config.SiteConfigsMu.RLock()
+	defer config.SiteConfigsMu.RUnlock()
 	for _, site := range config.SiteConfigs {
 		all = append(all, site)
 	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Domain < all[j].Domain
+	})
+	return all
+}
+
+func listSitesHandler(w http.ResponseWriter, r *http.Request) {
+	all := SitesSnapshot()
 	jsonResponse(w, all)
 }
 
 func getSiteHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	domain := vars["domain"]
+	config.SiteConfigsMu.RLock()
 	site, ok := config.SiteConfigs[domain]
+	config.SiteConfigsMu.RUnlock()
 	if !ok {
 		http.Error(w, "Site not found", http.StatusNotFound)
 		return
@@ -44,14 +57,18 @@ func createSiteHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to save site config", http.StatusInternalServerError)
 		return
 	}
+	config.SiteConfigsMu.Lock()
 	config.SiteConfigs[site.Domain] = site
+	config.SiteConfigsMu.Unlock()
 	jsonResponse(w, site)
 }
 
 func updateSiteHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	domain := vars["domain"]
+	config.SiteConfigsMu.RLock()
 	existing, ok := config.SiteConfigs[domain]
+	config.SiteConfigsMu.RUnlock()
 	if !ok {
 		http.Error(w, "Site not found", http.StatusNotFound)
 		return
@@ -74,7 +91,9 @@ func updateSiteHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to save site config", http.StatusInternalServerError)
 		return
 	}
+	config.SiteConfigsMu.Lock()
 	config.SiteConfigs[domain] = existing
+	config.SiteConfigsMu.Unlock()
 	jsonResponse(w, existing)
 }
 
@@ -86,14 +105,18 @@ func deleteSiteHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to delete site config", http.StatusInternalServerError)
 		return
 	}
+	config.SiteConfigsMu.Lock()
 	delete(config.SiteConfigs, domain)
+	config.SiteConfigsMu.Unlock()
 	jsonResponse(w, map[string]string{"deleted": domain})
 }
 
 func validateSiteHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	domain := vars["domain"]
+	config.SiteConfigsMu.RLock()
 	site, ok := config.SiteConfigs[domain]
+	config.SiteConfigsMu.RUnlock()
 	if !ok {
 		http.Error(w, "Site not found", http.StatusNotFound)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,8 @@ var customLogDir string
 
 // SiteConfigs is a global map of site configurations keyed by domain.
 var SiteConfigs = make(map[string]SiteConfig)
+var SiteConfigsMu sync.RWMutex
+var GlobalConfMu sync.RWMutex
 
 // SSLConfig represents the SSL configuration for a site.
 type SSLConfig struct {
@@ -148,7 +150,9 @@ func LoadAllConfigs() ([]SiteConfig, error) {
 
 				mu.Lock()
 				configs = append(configs, conf)
+				SiteConfigsMu.Lock()
 				SiteConfigs[conf.Domain] = conf
+				SiteConfigsMu.Unlock()
 				mu.Unlock()
 			}(file.Name())
 		}
@@ -173,6 +177,8 @@ func GetSiteConfigByHost(host string) (SiteConfig, error) {
 		host = host[:colonIndex]
 	}
 
+	SiteConfigsMu.RLock()
+	defer SiteConfigsMu.RUnlock()
 	if conf, ok := SiteConfigs[host]; ok {
 		return conf, nil
 	}

--- a/internal/config/global_config.go
+++ b/internal/config/global_config.go
@@ -46,6 +46,7 @@ func LoadGlobalConfig(customPath string) error {
 	}
 
 	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		GlobalConfMu.Lock()
 		GlobalConf = &GlobalConfig{
 			EnableAPI:      false,
 			APIPort:        6007,
@@ -53,6 +54,7 @@ func LoadGlobalConfig(customPath string) error {
 			EnabledPlugins: []string{},
 			DNS:            DefaultDNSConfig(),
 		}
+		GlobalConfMu.Unlock()
 		return nil
 	}
 
@@ -64,7 +66,9 @@ func LoadGlobalConfig(customPath string) error {
 	if err := json.Unmarshal(data, &conf); err != nil {
 		return err
 	}
+	GlobalConfMu.Lock()
 	GlobalConf = &conf
+	GlobalConfMu.Unlock()
 	return nil
 }
 
@@ -72,7 +76,9 @@ func LoadGlobalConfig(customPath string) error {
 func SaveGlobalConfig() error {
 	configDir := GetConfigDir()
 	configFile := filepath.Join(configDir, globalConfName)
+	GlobalConfMu.RLock()
 	data, err := json.MarshalIndent(GlobalConf, "", "    ")
+	GlobalConfMu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/internal/dashboard/datastar.go
+++ b/internal/dashboard/datastar.go
@@ -1,0 +1,207 @@
+package dashboard
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mirkobrombin/goup/internal/api"
+	"github.com/mirkobrombin/goup/internal/config"
+	"github.com/mirkobrombin/goup/internal/monitor"
+)
+
+func streamDashboardHandler(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if err := datastarPatchElements(w, dashboardFragments()); err != nil {
+			return
+		}
+		flusher.Flush()
+
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func datastarPatchElements(w http.ResponseWriter, fragments string) error {
+	if _, err := fmt.Fprintln(w, "event: datastar-patch-elements"); err != nil {
+		return err
+	}
+	for _, line := range strings.Split(fragments, "\n") {
+		if _, err := fmt.Fprintf(w, "data: elements %s\n", line); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintln(w)
+	return err
+}
+
+func dashboardFragments() string {
+	sites := api.SitesSnapshot()
+	metrics := api.MetricsSnapshot()
+	logWeight, err := api.LogWeightSnapshot()
+	if err != nil {
+		logWeight = 0
+	}
+	pluginUsage := api.PluginUsageSnapshot()
+	logs := monitor.RecentRequestLogs(20)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `<span id="live-sites-count" class="text-4xl font-bold">%d</span>`, len(sites))
+	fmt.Fprintf(&b, `<span id="live-vhosts-count" class="text-4xl font-bold">%d</span>`, vhostsCount(sites))
+	fmt.Fprintf(&b, `<span id="live-log-weight" class="text-4xl font-bold">%d</span>`, logWeight)
+	b.WriteString(renderHomeMetrics(metrics, logWeight, pluginUsage))
+	b.WriteString(renderMetrics(metrics, logWeight, pluginUsage))
+	b.WriteString(renderSites(sites))
+	b.WriteString(renderLogs(logs))
+	return b.String()
+}
+
+func renderHomeMetrics(metrics map[string]any, logWeight int64, pluginUsage map[string]int) string {
+	var b strings.Builder
+	b.WriteString(`<ul id="live-home-metrics" class="space-y-2 text-sm text-gray-600">`)
+	fmt.Fprintf(&b, `<li>Total Requests: <span>%s</span></li>`, metricValue(metrics["requests_total"]))
+	fmt.Fprintf(&b, `<li>Average Latency (ms): <span>%s</span></li>`, metricValue(metrics["latency_avg_ms"]))
+	fmt.Fprintf(&b, `<li>CPU Usage (%%): <span>%s</span></li>`, metricValue(metrics["cpu_usage"]))
+	fmt.Fprintf(&b, `<li>RAM Usage (MB): <span>%s</span></li>`, metricValue(metrics["ram_usage_mb"]))
+	fmt.Fprintf(&b, `<li>Log Files Size: <span>%d</span></li>`, logWeight)
+	b.WriteString(`<li>Plugins Usage:<ul class="ml-4">`)
+	writePluginUsage(&b, pluginUsage, `<li class="flex justify-between"><span>%s</span><span>%d</span></li>`)
+	b.WriteString(`</ul></li></ul>`)
+	return b.String()
+}
+
+func renderMetrics(metrics map[string]any, logWeight int64, pluginUsage map[string]int) string {
+	var b strings.Builder
+	b.WriteString(`<ul id="metricsList" class="space-y-2">`)
+	metricRows := []struct {
+		name  string
+		value any
+	}{
+		{"Requests Total", metrics["requests_total"]},
+		{"Average Latency (ms)", metrics["latency_avg_ms"]},
+		{"CPU Usage (%)", metrics["cpu_usage"]},
+		{"RAM Usage (MB)", metrics["ram_usage_mb"]},
+	}
+	for _, row := range metricRows {
+		fmt.Fprintf(&b, `<li class="flex justify-between border-b py-2"><span class="font-medium">%s</span><span>%s</span></li>`, row.name, metricValue(row.value))
+	}
+	fmt.Fprintf(&b, `<li class="flex justify-between border-b py-2"><span class="font-medium">Total Log Weight (bytes)</span><span>%d</span></li>`, logWeight)
+	b.WriteString(`</ul>`)
+	b.WriteString(`<ul id="pluginUsageList" class="space-y-1">`)
+	writePluginUsage(&b, pluginUsage, `<li class="flex justify-between border-b py-1"><span>%s</span><span>%d</span></li>`)
+	b.WriteString(`</ul>`)
+	return b.String()
+}
+
+func renderSites(sites []config.SiteConfig) string {
+	var b strings.Builder
+	b.WriteString(`<ul id="sitesList" class="divide-y divide-gray-200">`)
+	for _, site := range sites {
+		domain := html.EscapeString(site.Domain)
+		mode := "static"
+		if site.ProxyPass != "" {
+			mode = "proxy"
+		}
+		tls := "http"
+		if site.SSL.Enabled {
+			tls = "https"
+		}
+		fmt.Fprintf(&b, `<li class="px-4 flex items-center justify-between py-3 hover:bg-gray-50 transition-colors duration-200 ease-in-out rounded-lg">`)
+		fmt.Fprintf(&b, `<div><p class="font-medium text-gray-700">%s</p><p class="text-sm text-gray-400">Port: %d | %s | %s</p></div>`, domain, site.Port, mode, tls)
+		fmt.Fprintf(&b, `<div class="flex items-center space-x-4"><button class="view-json text-blue-600 hover:text-blue-500 text-sm font-medium" data-domain="%s"><span class="material-symbols-outlined"> data_object </span></button><button class="delete-site text-red-500 hover:text-red-400 text-sm font-medium" data-domain="%s"><span class="material-symbols-outlined"> delete </span></button></div>`, domain, domain)
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`</ul>`)
+	return b.String()
+}
+
+func renderLogs(logs []monitor.RequestLog) string {
+	var b strings.Builder
+	b.WriteString(`<div id="liveLogs" class="space-y-2 text-sm">`)
+	if len(logs) == 0 {
+		b.WriteString(`<p class="text-gray-400">No requests yet.</p>`)
+	} else {
+		for i := len(logs) - 1; i >= 0; i-- {
+			entry := logs[i]
+			domain := html.EscapeString(entry.Domain)
+			if domain == "" {
+				domain = html.EscapeString(entry.Identifier)
+			}
+			fmt.Fprintf(&b, `<div class="bg-gray-50 border border-gray-200 rounded p-2 shadow-sm">`)
+			fmt.Fprintf(&b, `<div class="text-xs text-gray-500 mb-1"><span class="font-semibold">%s</span> <span>%s</span></div>`, entry.Time.Format("15:04:05"), domain)
+			fmt.Fprintf(&b, `<div class="text-gray-800">%s %s %d (%.4fs)</div>`, html.EscapeString(entry.Method), html.EscapeString(entry.URL), entry.StatusCode, entry.DurationSec)
+			b.WriteString(`</div>`)
+		}
+	}
+	b.WriteString(`</div>`)
+	return b.String()
+}
+
+func writePluginUsage(b *strings.Builder, usage map[string]int, format string) {
+	names := make([]string, 0, len(usage))
+	for name := range usage {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		fmt.Fprintf(b, format, "none", 0)
+		return
+	}
+	for _, name := range names {
+		fmt.Fprintf(b, format, html.EscapeString(name), usage[name])
+	}
+}
+
+func metricValue(value any) string {
+	switch v := value.(type) {
+	case []float64:
+		if len(v) == 0 {
+			return "0"
+		}
+		return fmt.Sprintf("%.2f", v[0])
+	case float64:
+		return fmt.Sprintf("%.2f", v)
+	case uint64:
+		return fmt.Sprintf("%d", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	default:
+		return html.EscapeString(fmt.Sprint(v))
+	}
+}
+
+func vhostsCount(sites []config.SiteConfig) int {
+	ports := make(map[int]int)
+	for _, site := range sites {
+		ports[site.Port]++
+	}
+	count := 0
+	for _, portCount := range ports {
+		if portCount > 1 {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/dashboard/datastar_test.go
+++ b/internal/dashboard/datastar_test.go
@@ -1,0 +1,77 @@
+package dashboard
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDatastarPatchElements(t *testing.T) {
+	rec := httptest.NewRecorder()
+	err := datastarPatchElements(rec, `<span id="live-sites-count">1</span>`)
+	if err != nil {
+		t.Fatalf("datastarPatchElements returned error: %v", err)
+	}
+
+	body := rec.Body.String()
+	checks := []string{
+		"event: datastar-patch-elements\n",
+		"data: elements <span id=\"live-sites-count\">1</span>\n",
+		"\n\n",
+	}
+	for _, check := range checks {
+		if !strings.Contains(body, check) {
+			t.Fatalf("expected stream to contain %q, got %q", check, body)
+		}
+	}
+}
+
+func TestStreamDashboardHandlerWritesDatastarEvent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest("GET", "/datastar/dashboard", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		streamDashboardHandler(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("streamDashboardHandler did not stop after context cancel")
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: datastar-patch-elements\n") {
+		t.Fatalf("expected Datastar event, got %q", body)
+	}
+	if !rec.Flushed {
+		t.Fatal("expected stream to flush")
+	}
+}
+
+func TestDashboardFragmentsContainDatastarTargets(t *testing.T) {
+	fragments := dashboardFragments()
+	targets := []string{
+		`id="live-sites-count"`,
+		`id="live-vhosts-count"`,
+		`id="live-log-weight"`,
+		`id="live-home-metrics"`,
+		`id="metricsList"`,
+		`id="pluginUsageList"`,
+		`id="sitesList"`,
+		`id="liveLogs"`,
+	}
+	for _, target := range targets {
+		if !strings.Contains(fragments, target) {
+			t.Fatalf("expected fragments to contain %s", target)
+		}
+	}
+}

--- a/internal/dashboard/handler.go
+++ b/internal/dashboard/handler.go
@@ -17,7 +17,11 @@ var content embed.FS
 
 // apiProxy returns a reverse proxy handler to forward /api calls to the backend.
 func apiProxy() http.Handler {
-	target, err := url.Parse(fmt.Sprintf("http://localhost:%d", config.GlobalConf.APIPort))
+	config.GlobalConfMu.RLock()
+	apiPort := config.GlobalConf.APIPort
+	config.GlobalConfMu.RUnlock()
+
+	target, err := url.Parse(fmt.Sprintf("http://localhost:%d", apiPort))
 	if err != nil {
 		panic(err)
 	}
@@ -25,8 +29,11 @@ func apiProxy() http.Handler {
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
 		originalDirector(req)
-		if config.GlobalConf != nil && config.GlobalConf.Account.APIToken != "" {
-			req.Header.Set("X-API-Token", config.GlobalConf.Account.APIToken)
+		config.GlobalConfMu.RLock()
+		conf := config.GlobalConf
+		config.GlobalConfMu.RUnlock()
+		if conf != nil && conf.Account.APIToken != "" {
+			req.Header.Set("X-API-Token", conf.Account.APIToken)
 		}
 	}
 	return proxy
@@ -54,6 +61,7 @@ func Handler() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.Handle("/api/", apiProxy())
+	mux.HandleFunc("/datastar/dashboard", streamDashboardHandler)
 
 	subFS, err := fs.Sub(content, "static")
 	if err != nil {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -10,10 +10,14 @@ import (
 
 // StartDashboardServer starts a dedicated server for the dashboard.
 func StartDashboardServer() *http.Server {
-	if config.GlobalConf == nil || config.GlobalConf.DashboardPort == 0 {
+	config.GlobalConfMu.RLock()
+	conf := config.GlobalConf
+	config.GlobalConfMu.RUnlock()
+
+	if conf == nil || conf.DashboardPort == 0 {
 		return nil
 	}
-	port := config.GlobalConf.DashboardPort
+	port := conf.DashboardPort
 	handler := Handler()
 	handler = middleware.BasicAuthMiddleware(handler)
 

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -9,6 +9,7 @@
     <script src="https://unpkg.com/navigo"></script>
     <script src="https://cdn.jsdelivr.net/npm/handlebars@latest/dist/handlebars.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js"></script>
     <script type="module" src="/entry.js"></script>
 </head>
 
@@ -41,6 +42,7 @@
     </header>
 
     <main id="app" class="max-w-screen-xl mx-auto px-4 py-6"></main>
+    <div data-init="@get('/datastar/dashboard')"></div>
 </body>
 
 </html>

--- a/internal/dashboard/static/js/sites.js
+++ b/internal/dashboard/static/js/sites.js
@@ -14,9 +14,11 @@ export default {
     const html = template({ sites: sitesData });
     document.querySelector(containerId).innerHTML = html;
 
-    document.querySelectorAll(".view-json").forEach((button) => {
-      button.addEventListener("click", async (e) => {
-        const domain = e.currentTarget.dataset.domain;
+    const sitesList = document.getElementById("sitesList");
+    sitesList.addEventListener("click", async (e) => {
+      const viewButton = e.target.closest(".view-json");
+      if (viewButton) {
+        const domain = viewButton.dataset.domain;
         if (!domain) return;
 
         const siteResp = await fetch(`/api/sites/${domain}`);
@@ -64,12 +66,12 @@ export default {
             },
           ],
         });
-      });
-    });
+        return;
+      }
 
-    document.querySelectorAll(".delete-site").forEach((button) => {
-      button.addEventListener("click", async (e) => {
-        const domain = e.target.dataset.domain;
+      const deleteButton = e.target.closest(".delete-site");
+      if (deleteButton) {
+        const domain = deleteButton.dataset.domain;
         if (confirm(`Are you sure you want to delete ${domain}?`)) {
           await fetch(`/api/sites/${domain}`, { method: "DELETE" });
           Toast.show("Site deleted. Restarting server...", "error", 3000);
@@ -78,7 +80,7 @@ export default {
             6000
           );
         }
-      });
+      }
     });
 
     window.currentView.applySearch = (searchTerm) => {

--- a/internal/dashboard/static/templates/home.html
+++ b/internal/dashboard/static/templates/home.html
@@ -2,15 +2,15 @@
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div class="bg-white rounded-xl shadow p-4 flex items-center space-x-4">
-            <span class="text-4xl font-bold">{{sitesCount}}</span>
+            <span id="live-sites-count" class="text-4xl font-bold">{{sitesCount}}</span>
             <span class="mt-2">Total Sites</span>
         </div>
         <div class="bg-white rounded-xl shadow p-4 flex items-center space-x-4">
-            <span class="text-4xl font-bold">{{vhostsCount}}</span>
+            <span id="live-vhosts-count" class="text-4xl font-bold">{{vhostsCount}}</span>
             <span class="mt-2">Virtual Hosts</span>
         </div>
         <div class="bg-white rounded-xl shadow p-4 flex items-center space-x-4">
-            <span class="text-4xl font-bold">{{totalLogWeight}}</span>
+            <span id="live-log-weight" class="text-4xl font-bold">{{totalLogWeight}}</span>
             <span class="mt-2">Log Weight (bytes)</span>
         </div>
     </div>
@@ -27,7 +27,7 @@
         <div class="bg-white rounded-xl shadow p-6 space-y-6">
             <div>
                 <h3 class="text-lg font-semibold mb-2">Real-Time Metrics</h3>
-                <ul class="space-y-2 text-sm text-gray-600">
+                <ul id="live-home-metrics" class="space-y-2 text-sm text-gray-600">
                     <li>Total Requests: <span>{{metrics.requests_total}}</span></li>
                     <li>Average Latency (ms): <span>{{metrics.latency_avg_ms}}</span></li>
                     <li>CPU Usage (%): <span>{{metrics.cpu_usage}}</span></li>

--- a/internal/dashboard/static/templates/logs.html
+++ b/internal/dashboard/static/templates/logs.html
@@ -15,6 +15,13 @@
 
     <button id="fetchLogsBtn" class="bg-cyan-600 text-white px-6 py-2 rounded hover:bg-cyan-500">Fetch Logs</button>
 
+    <div class="mt-6">
+        <h3 class="text-xl font-bold mb-2">Live Requests</h3>
+        <div id="liveLogs" class="space-y-2 text-sm">
+            <p class="text-gray-400">No requests yet.</p>
+        </div>
+    </div>
+
     <ul class="divide-y divide-gray-200 mt-4" id="logsList"></ul>
 </div>
 

--- a/internal/dashboard/static/templates/metrics.html
+++ b/internal/dashboard/static/templates/metrics.html
@@ -1,7 +1,7 @@
 <div class="bg-white p-6 rounded-xl shadow space-y-4">
     <h2 class="text-2xl font-bold text-gray-700 mb-4">Metrics</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <ul class="space-y-2">
+        <ul id="metricsList" class="space-y-2">
             {{#each metrics}}
             <li class="flex justify-between border-b py-2">
                 <span class="font-medium">{{this.name}}</span>
@@ -19,7 +19,7 @@
     </div>
     <div class="mt-4">
         <h3 class="text-xl font-bold mb-2">Plugin Usage</h3>
-        <ul class="space-y-1">
+        <ul id="pluginUsageList" class="space-y-1">
             {{#each pluginUsage}}
             <li class="flex justify-between border-b py-1">
                 <span>{{@key}}</span>

--- a/internal/dashboard/static/templates/sites.html
+++ b/internal/dashboard/static/templates/sites.html
@@ -2,7 +2,7 @@
     <h2 class="text-2xl font-bold text-gray-700">Sites</h2>
     <p class="text-sm text-gray-500 mb-4">Filtered by domain name if you type in the global search.</p>
 
-    <ul class="divide-y divide-gray-200">
+    <ul id="sitesList" class="divide-y divide-gray-200">
         {{#each sites}}
         <li
             class="px-4 flex items-center justify-between py-3 hover:bg-gray-50 transition-colors duration-200 ease-in-out rounded-lg">

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -12,20 +12,24 @@ import (
 // BasicAuthMiddleware enforces Basic Authentication if credentials are configured.
 func BasicAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		config.GlobalConfMu.RLock()
+		conf := config.GlobalConf
+		config.GlobalConfMu.RUnlock()
+
 		// If auth is not configured, skip
-		if config.GlobalConf == nil || config.GlobalConf.Account.Username == "" || config.GlobalConf.Account.PasswordHash == "" {
+		if conf == nil || conf.Account.Username == "" || conf.Account.PasswordHash == "" {
 			next.ServeHTTP(w, r)
 			return
 		}
 
 		user, pass, ok := r.BasicAuth()
-		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(config.GlobalConf.Account.Username)) != 1 {
+		if !ok || subtle.ConstantTimeCompare([]byte(user), []byte(conf.Account.Username)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="GoUp Dashboard"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		err := bcrypt.CompareHashAndPassword([]byte(config.GlobalConf.Account.PasswordHash), []byte(pass))
+		err := bcrypt.CompareHashAndPassword([]byte(conf.Account.PasswordHash), []byte(pass))
 		if err != nil {
 			w.Header().Set("WWW-Authenticate", `Basic realm="GoUp Dashboard"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -39,8 +43,12 @@ func BasicAuthMiddleware(next http.Handler) http.Handler {
 // TokenAuthMiddleware enforces Token Authentication if a token is configured.
 func TokenAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		config.GlobalConfMu.RLock()
+		conf := config.GlobalConf
+		config.GlobalConfMu.RUnlock()
+
 		// If token is not configured, skip
-		if config.GlobalConf == nil || config.GlobalConf.Account.APIToken == "" {
+		if conf == nil || conf.Account.APIToken == "" {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -53,7 +61,7 @@ func TokenAuthMiddleware(next http.Handler) http.Handler {
 			}
 		}
 
-		if subtle.ConstantTimeCompare([]byte(token), []byte(config.GlobalConf.Account.APIToken)) != 1 {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(conf.Account.APIToken)) != 1 {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mirkobrombin/goup/internal/logger"
+)
+
+type RequestLog struct {
+	Time        time.Time
+	Identifier  string
+	Domain      string
+	Method      string
+	URL         string
+	StatusCode  int
+	DurationSec float64
+}
+
+const maxRequestLogs = 100
+
+var requestCount uint64
+
+var requestLogs = struct {
+	sync.RWMutex
+	items []RequestLog
+}{}
+
+func AddRequestLog(identifier string, fields logger.Fields) {
+	atomic.AddUint64(&requestCount, 1)
+	entry := RequestLog{
+		Time:       time.Now(),
+		Identifier: identifier,
+	}
+	entry.Domain, _ = fields["domain"].(string)
+	entry.Method, _ = fields["method"].(string)
+	entry.URL, _ = fields["url"].(string)
+	entry.StatusCode, _ = fields["status_code"].(int)
+	entry.DurationSec, _ = fields["duration_sec"].(float64)
+
+	requestLogs.Lock()
+	requestLogs.items = append(requestLogs.items, entry)
+	if len(requestLogs.items) > maxRequestLogs {
+		requestLogs.items = requestLogs.items[len(requestLogs.items)-maxRequestLogs:]
+	}
+	requestLogs.Unlock()
+}
+
+func RecentRequestLogs(limit int) []RequestLog {
+	requestLogs.RLock()
+	defer requestLogs.RUnlock()
+
+	if limit <= 0 || limit > len(requestLogs.items) {
+		limit = len(requestLogs.items)
+	}
+
+	start := len(requestLogs.items) - limit
+	items := make([]RequestLog, limit)
+	copy(items, requestLogs.items[start:])
+	return items
+}
+
+func RequestCount() uint64 {
+	return atomic.LoadUint64(&requestCount)
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -120,6 +120,8 @@ func (pm *PluginManager) GetRegisteredPlugins() []string {
 }
 
 func isPluginEnabled(name string) bool {
+	config.GlobalConfMu.RLock()
+	defer config.GlobalConfMu.RUnlock()
 	if config.GlobalConf == nil || len(config.GlobalConf.EnabledPlugins) == 0 {
 		return true
 	}

--- a/internal/safeguard/safeguard.go
+++ b/internal/safeguard/safeguard.go
@@ -17,10 +17,14 @@ var log *logger.Logger
 
 // Start starts the SafeGuard routine if enabled.
 func Start() {
-	if config.GlobalConf == nil {
+	config.GlobalConfMu.RLock()
+	globalConf := config.GlobalConf
+	config.GlobalConfMu.RUnlock()
+
+	if globalConf == nil {
 		return
 	}
-	conf := config.GlobalConf.SafeGuard
+	conf := globalConf.SafeGuard
 
 	// Default: Enabled if not explicitly set to false
 	if conf.Enable != nil && !*conf.Enable {

--- a/internal/server/middleware/async_logger.go
+++ b/internal/server/middleware/async_logger.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/mirkobrombin/goup/internal/logger"
+	"github.com/mirkobrombin/goup/internal/monitor"
 	"github.com/mirkobrombin/goup/internal/tui"
 )
 
@@ -74,6 +75,7 @@ func (al *AsyncLogger) PutEntry(entry *LogEntry) {
 func (al *AsyncLogger) worker() {
 	for entry := range al.logChan {
 		entry.Logger.WithFields(entry.Fields).Info(entry.Message)
+		monitor.AddRequestLog(entry.Identifier, entry.Fields)
 
 		if tui.IsEnabled() {
 			tui.UpdateLog(entry.Identifier, entry.Fields)

--- a/internal/server/middleware/middleware.go
+++ b/internal/server/middleware/middleware.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mirkobrombin/goup/internal/logger"
+	"github.com/mirkobrombin/goup/internal/monitor"
 	"github.com/mirkobrombin/goup/internal/tui"
 )
 
@@ -68,6 +69,7 @@ func LoggingMiddleware(l *logger.Logger, domain string, identifier string) Middl
 					"domain":       domain,
 				}
 				l.WithFields(fields).Info("Handled request")
+				monitor.AddRequestLog(identifier, fields)
 				if tui.IsEnabled() {
 					tui.UpdateLog(identifier, fields)
 				}

--- a/internal/server/server_dns.go
+++ b/internal/server/server_dns.go
@@ -11,11 +11,15 @@ import (
 )
 
 func launchDNS(wg *sync.WaitGroup) {
-	if config.GlobalConf != nil && config.GlobalConf.DNS != nil && config.GlobalConf.DNS.Enable {
+	config.GlobalConfMu.RLock()
+	conf := config.GlobalConf
+	config.GlobalConfMu.RUnlock()
+
+	if conf != nil && conf.DNS != nil && conf.DNS.Enable {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			dns.Start(config.GlobalConf.DNS)
+			dns.Start(conf.DNS)
 		}()
 	}
 }


### PR DESCRIPTION
Closes #9.

- Adds an SSE stream to the dashboard powered by Datastar for live metrics, site status and logs, reusing the existing API/monitor infrastructure.
- Dashboard remains disabled by default.

Verified: build, vet and full test suite green.