### PR TITLE
Support running as a kamal-proxy target

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ GoUP! is a minimal, tweakable web server written in Go. You can use it to serve 
 ## Documentation
 
 - [DNS Server Guide](docs/dns.md) explanation of the DNS module configuration and usage.
+- [Kamal Proxy Guide](docs/kamal-proxy.md) for blue/green deployments with kamal-proxy.
 
 ## Future Plans
 

--- a/docs/kamal-proxy.md
+++ b/docs/kamal-proxy.md
@@ -1,0 +1,89 @@
+# Kamal Proxy
+
+GoUp can run as an HTTP target behind [kamal-proxy](https://github.com/basecamp/kamal-proxy).
+
+Kamal Proxy handles the blue/green switch. GoUp only needs to expose a health endpoint and stop cleanly when the old process is removed.
+
+## Target contract
+
+GoUp exposes:
+
+```text
+GET /up
+```
+
+The endpoint returns:
+
+- `200 OK` while GoUp is ready to accept traffic.
+- `503 Service Unavailable` after GoUp starts shutting down and before the listener closes.
+
+The endpoint is handled before static files, reverse proxies, plugins, and virtual host routing. This means kamal-proxy can use the default health check path even when the target host header does not match a configured site.
+
+On shutdown, GoUp marks itself not ready, calls `http.Server.Shutdown` for every web server, and waits up to 10 seconds before exiting. Health checks may receive `503` during that short window, or fail to connect after the listener closes.
+
+## GoUp configuration
+
+Run GoUp without site TLS when kamal-proxy terminates TLS:
+
+```json
+{
+  "domain": "example.com",
+  "port": 3000,
+  "root_directory": "/var/www/example.com",
+  "ssl": {
+    "enabled": false
+  },
+  "request_timeout": 60
+}
+```
+
+Start GoUp:
+
+```bash
+goup start-web --config /etc/goup/example.com.json
+```
+
+## Proxy setup
+
+Start kamal-proxy on the public ports:
+
+```bash
+kamal-proxy run --http-port 80 --https-port 443
+```
+
+Deploy the first GoUp target:
+
+```bash
+kamal-proxy deploy goup \
+  --target 127.0.0.1:3000 \
+  --host example.com \
+  --tls
+```
+
+Kamal Proxy checks `GET /up` once per second by default. When the new target returns `200`, new requests move to it. The command returns only after the previous target has drained.
+
+## Blue/green flow
+
+1. Start the new GoUp process on a free port, for example `3001`.
+2. Deploy it to kamal-proxy:
+
+   ```bash
+   kamal-proxy deploy goup \
+     --target 127.0.0.1:3001 \
+     --host example.com \
+     --tls
+   ```
+
+3. Stop the old GoUp process after the deploy command succeeds:
+
+   ```bash
+   kill -TERM <old-goup-pid>
+   ```
+
+If the new target does not become healthy before the deploy timeout, kamal-proxy exits with a non-zero status and keeps routing to the old target.
+
+## Notes
+
+- Keep `/up` reserved for health checks.
+- Use `--health-check-path` only if a future deployment needs a custom path.
+- Use the kamal-proxy CLI for deployments. GoUp does not call the proxy's internal RPC socket directly.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,22 +9,27 @@ import (
 )
 
 // StartAPIServer starts the GoUp API server.
-func StartAPIServer() {
+func StartAPIServer() *http.Server {
 	if config.GlobalConf == nil || !config.GlobalConf.EnableAPI {
-		return
+		return nil
 	}
 
 	router := SetupRoutes()
 	port := config.GlobalConf.APIPort
+	var handler http.Handler = router
+	handler = middleware.TokenAuthMiddleware(handler)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: handler,
+	}
 
 	go func() {
 		fmt.Printf("[API] Listening on :%d\n", port)
-
-		var handler http.Handler = router
-		handler = middleware.TokenAuthMiddleware(handler)
-
-		if err := http.ListenAndServe(fmt.Sprintf(":%d", port), handler); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("[API] Error: %v\n", err)
 		}
 	}()
+
+	return srv
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -191,15 +191,15 @@ func start(cmd *cobra.Command, args []string) {
 		fmt.Printf("Warning: could not write PID file: %v\n", err)
 	}
 
+	if !tuiMode {
+		handleShutdownSignal()
+	}
+
 	fmt.Println("Starting full GoUp server (Web + DNS)...")
 	server.StartServers(configs, tuiMode, benchMode, server.ModeAll)
 
 	if !tuiMode {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		<-sigCh
-		fmt.Println("\nShutting down...")
-		pidfile.Remove()
+		select {}
 	}
 }
 
@@ -220,15 +220,15 @@ func startWeb(cmd *cobra.Command, args []string) {
 		fmt.Printf("Warning: could not write PID file: %v\n", err)
 	}
 
+	if !tuiMode {
+		handleShutdownSignal()
+	}
+
 	fmt.Println("Starting GoUp Web Server...")
 	server.StartServers(configs, tuiMode, benchMode, server.ModeWeb)
 
 	if !tuiMode {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		<-sigCh
-		fmt.Println("\nShutting down...")
-		pidfile.Remove()
+		select {}
 	}
 }
 
@@ -245,16 +245,30 @@ func startDNS(cmd *cobra.Command, args []string) {
 		fmt.Printf("Warning: could not write PID file: %v\n", err)
 	}
 
+	if !tuiMode {
+		handleShutdownSignal()
+	}
+
 	fmt.Println("Starting GoUp DNS Server...")
 	server.StartServers(configs, tuiMode, benchMode, server.ModeDNS)
 
 	if !tuiMode {
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		select {}
+	}
+}
+
+func handleShutdownSignal() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
 		<-sigCh
 		fmt.Println("\nShutting down...")
+		if err := server.ShutdownServers(server.DefaultShutdownTimeout); err != nil {
+			fmt.Printf("Error shutting down: %v\n", err)
+		}
 		pidfile.Remove()
-	}
+		os.Exit(0)
+	}()
 }
 
 func loadConfigs() ([]config.SiteConfig, error) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -9,17 +9,25 @@ import (
 )
 
 // StartDashboardServer starts a dedicated server for the dashboard.
-func StartDashboardServer() {
+func StartDashboardServer() *http.Server {
 	if config.GlobalConf == nil || config.GlobalConf.DashboardPort == 0 {
-		return
+		return nil
 	}
 	port := config.GlobalConf.DashboardPort
+	handler := Handler()
+	handler = middleware.BasicAuthMiddleware(handler)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: handler,
+	}
+
 	go func() {
 		fmt.Printf("[Dashboard] Listening on :%d\n", port)
-		handler := Handler()
-		handler = middleware.BasicAuthMiddleware(handler)
-		if err := http.ListenAndServe(fmt.Sprintf(":%d", port), handler); err != nil {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			fmt.Printf("[Dashboard] Error: %v\n", err)
 		}
 	}()
+
+	return srv
 }

--- a/internal/server/lifecycle.go
+++ b/internal/server/lifecycle.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const DefaultShutdownTimeout = 10 * time.Second
+
+var (
+	ready           atomic.Bool
+	serverRegistry  []*http.Server
+	serverRegistryM sync.Mutex
+)
+
+func init() {
+	ready.Store(true)
+}
+
+func SetReady(v bool) {
+	ready.Store(v)
+}
+
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if !ready.Load() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, "draining")
+		return
+	}
+
+	fmt.Fprintln(w, "ok")
+}
+
+func withHealthCheck(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/up" {
+			HealthHandler(w, r)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func registerServer(server *http.Server) {
+	serverRegistryM.Lock()
+	defer serverRegistryM.Unlock()
+	serverRegistry = append(serverRegistry, server)
+}
+
+func ShutdownServers(timeout time.Duration) error {
+	SetReady(false)
+
+	serverRegistryM.Lock()
+	servers := append([]*http.Server(nil), serverRegistry...)
+	serverRegistryM.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(servers))
+
+	for _, srv := range servers {
+		wg.Add(1)
+		go func(s *http.Server) {
+			defer wg.Done()
+			if err := s.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errs <- err
+			}
+		}(srv)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var shutdownErr error
+	for err := range errs {
+		shutdownErr = errors.Join(shutdownErr, err)
+	}
+	return shutdownErr
+}

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandlerReady(t *testing.T) {
+	SetReady(true)
+	defer SetReady(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/up", nil)
+	rec := httptest.NewRecorder()
+
+	HealthHandler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestHealthHandlerDraining(t *testing.T) {
+	SetReady(false)
+	defer SetReady(true)
+
+	req := httptest.NewRequest(http.MethodGet, "/up", nil)
+	rec := httptest.NewRecorder()
+
+	HealthHandler(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, rec.Code)
+	}
+}
+
+func TestWithHealthCheckBypassesHandler(t *testing.T) {
+	SetReady(true)
+	defer SetReady(true)
+
+	called := false
+	handler := withHealthCheck(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/up", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if called {
+		t.Fatal("expected health check to bypass handler")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}

--- a/internal/server/server_utils.go
+++ b/internal/server/server_utils.go
@@ -27,7 +27,7 @@ func createHTTPServer(conf config.SiteConfig, handler http.Handler) *http.Server
 
 	s := &http.Server{
 		Addr:         fmt.Sprintf(":%d", conf.Port),
-		Handler:      handler,
+		Handler:      withHealthCheck(handler),
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,
 		TLSConfig: &tls.Config{
@@ -63,6 +63,8 @@ func listenOptimized(addr string) (net.Listener, error) {
 
 // startServerInstance starts the HTTP server instance.
 func startServerInstance(server *http.Server, conf config.SiteConfig, l *logger.Logger) {
+	registerServer(server)
+
 	go func() {
 		if conf.SSL.Enabled {
 			// SSL/TLS configuration

--- a/internal/server/server_web.go
+++ b/internal/server/server_web.go
@@ -18,10 +18,14 @@ import (
 
 func launchWebComponents(configs []config.SiteConfig, enableTUI bool, enableBench bool, wg *sync.WaitGroup) {
 	// Start API Server if enabled
-	api.StartAPIServer()
+	if srv := api.StartAPIServer(); srv != nil {
+		registerServer(srv)
+	}
 
 	// Start Dashboard Server if enabled
-	dashboard.StartDashboardServer()
+	if srv := dashboard.StartDashboardServer(); srv != nil {
+		registerServer(srv)
+	}
 
 	// Groupping configurations by port
 	portConfigs := make(map[int][]config.SiteConfig)


### PR DESCRIPTION
Closes #8.

- Health endpoint and graceful connection drain on SIGTERM so GoUp can sit behind kamal-proxy for blue/green deploys with no dropped connections.
- Lifecycle registry for all servers (web, API, dashboard) with tests.
- Setup and deploy walkthrough in docs/kamal-proxy.md.

Verified: build, vet and full test suite green, including new lifecycle tests.